### PR TITLE
Fix renderToStream API call

### DIFF
--- a/2017/reactrally/fiber.md
+++ b/2017/reactrally/fiber.md
@@ -602,7 +602,8 @@ NOTES:
 ## First-class server-side streaming support! 🎉
 
 ```js
-import {renderToNodeStream} from 'react-dom/server'
+// will soon be renamed renderToNodeStream in a future release!
+import {renderToStream} from 'react-dom/server'
 
 app.get('/', (req, res) => {
   // write opening <html>, <head>, <body> tags streamed


### PR DESCRIPTION
Hi,

Thanks for the awesome talk at React Rally! 👏 😃 

I was playing around with the new version of `react-dom` (`16.0.0-beta.5`) to try and use the streaming API, following your example.

Although the API used will be correct soon (https://github.com/facebook/react/pull/10425), the current `@next` release (`16.0.0-beta.5`) appears to still use the old API.

(Probably not be worth merging if it's being released soon - just mentioning it in case someone else runs into this for now.)

Thanks again!